### PR TITLE
fix github links in sidebar

### DIFF
--- a/ruqqus/templates/help/about.html
+++ b/ruqqus/templates/help/about.html
@@ -198,7 +198,7 @@
                     </li>
                 </ul>
 
-                <a href="https://github.com/thecodeforge/ruqqus-reborn" class="btn btn-lg btn-primary shadow-md d-none d-md-inline-block">View our code</a>
+                <a href="https://github.com/thecodeforge/syzitus" class="btn btn-lg btn-primary shadow-md d-none d-md-inline-block">View our code</a>
 
             </div>
 

--- a/ruqqus/templates/help/donate.html
+++ b/ruqqus/templates/help/donate.html
@@ -200,7 +200,7 @@
                     </li>
                 </ul>
 
-                <a href="https://github.com/thecodeforge/ruqqus-reborn" class="btn btn-lg btn-primary shadow-md d-none d-md-inline-block">View our code</a>
+                <a href="https://github.com/thecodeforge/syzitus" class="btn btn-lg btn-primary shadow-md d-none d-md-inline-block">View our code</a>
 
             </div>
 

--- a/ruqqus/templates/home.html
+++ b/ruqqus/templates/home.html
@@ -271,7 +271,7 @@
       <div class="body">
         <p>Support {{ 'SITE_NAME' | app_config }} today!</p>
 
-        <a href="https://github.com/thecodeforge/ruqqus-reborn" target="blank" class="btn btn-block btn-link text-black text-left text-decoration-none px-1 mt-0">
+        <a href="https://github.com/thecodeforge/syzitus" target="blank" class="btn btn-block btn-link text-black text-left text-decoration-none px-1 mt-0">
           <span class="fa-stack fa-1x ml-n1 mr-2">
             <i class="fas fa-square fa-stack-2x text-gray-300" style="font-size: 2rem!important;"></i>
             <i class="fab fa-github fa-stack-1x text-black text-base fa-inverse"></i>

--- a/ruqqus/templates/userpage.html
+++ b/ruqqus/templates/userpage.html
@@ -239,7 +239,7 @@
   <div class="body">
     <p>Merch and more. Support {{ "SITE_NAME" | app_config }} today!</p>
 
-    <a href="https://github.com/thecodeforge/ruqqus-reborn" target="blank" class="btn btn-block btn-link text-black text-left text-decoration-none px-1 mt-0">
+    <a href="https://github.com/thecodeforge/syzitus" target="blank" class="btn btn-block btn-link text-black text-left text-decoration-none px-1 mt-0">
       <span class="fa-stack fa-1x ml-n1 mr-2">
         <i class="fas fa-square fa-stack-2x text-gray-300" style="font-size: 2rem!important;"></i>
         <i class="fab fa-github fa-stack-1x text-black text-base fa-inverse"></i>
@@ -260,7 +260,7 @@
       </span>{{ "SITE_NAME" | app_config }} Premium
     </a>
 
-    <a href="https://github.com/thecodeforge/ruqqus-reborn/issues" target="blank" class="btn btn-block btn-link text-left text-decoration-none px-1 mt-0" style="color: #DC143C!important">
+    <a href="https://github.com/thecodeforge/syzitus/issues" target="blank" class="btn btn-block btn-link text-left text-decoration-none px-1 mt-0" style="color: #DC143C!important">
       <span class="fa-stack fa-1x ml-n1 mr-2">
         <i class="fas fa-square fa-stack-2x" style="color: #FC8181!important; font-size: 2rem!important;"></i>
         <i class="fas fa-bug fa-stack-1x text-base fa-inverse" style="color: #DC143C!important;"></i>


### PR DESCRIPTION
This PR replaces all mentions of `ruqqus-reborn` *(previous project codename? wonder what that's all about)* on the website with `syzitus` *(the real project name)*.