### PR TITLE
Fix guildmaster invite accept button event.

### DIFF
--- a/syzitus/templates/guild/gm_invitation_modal.html
+++ b/syzitus/templates/guild/gm_invitation_modal.html
@@ -6,7 +6,7 @@
           <i class="fad fa-crown text-warning" style="font-size: 3.5rem;"></i>
         </div>
         <p>You've been invited to be a guildmaster of <span class="font-weight-bold">+{{ b.name }}</span>. You will have full permissions over the guild.</p>
-        <a class="btn btn-primary btn-block toast-post-url-reload" href="javascript:void(0)" data-post-url="/mod/accept/{{ b.base36id }}">Accept Invitation</a>
+        <a class="btn btn-primary btn-block post-toast-url-reload" href="javascript:void(0)" data-post-url="/mod/accept/{{ b.base36id }}">Accept Invitation</a>
         <button type="button" class="btn btn-link text-muted mt-2" data-dismiss="modal">Ignore</button>
       </div>
     </div>


### PR DESCRIPTION
Commit 4b3ac90436 used `toast-post-url-reload` whereas the class name bound to by the query selector in all_js.js L2195 is `post-toast-url-reload`.