### PR TITLE
Fix missing username and email address in verification email

### DIFF
--- a/syzitus/mail/mail.py
+++ b/syzitus/mail/mail.py
@@ -53,7 +53,9 @@ def send_verification_email(user, email=None):
     send_mail(to_address=email,
               html=render_template(
                 "email/email_verify.html",
-                action_url=link
+                action_url=link,
+                user_username=user.username,
+                user_email_address=email
                 ),
               subject=f"Verify your {app.config['SITE_NAME']} account email."
               )

--- a/syzitus/templates/email/email_verify.html
+++ b/syzitus/templates/email/email_verify.html
@@ -28,14 +28,14 @@
                                 <tr>
                                   <td class="attributes_item">
                                     <span class="f-fallback">
-              <strong>Email:</strong> {{ g.user.email }}
+              <strong>Email:</strong> {{ user_email_address }}
             </span>
                                   </td>
                                 </tr>
                                 <tr>
                                   <td class="attributes_item">
                                     <span class="f-fallback">
-              <strong>Username:</strong> {{ g.user.username }}
+              <strong>Username:</strong> {{ user_username }}
             </span>
                                   </td>
                                 </tr>


### PR DESCRIPTION
* Explicitly pass through username & email address when rendering verification mail
* Fixes: https://github.com/TheCodeForge/syzitus/issues/12